### PR TITLE
improved batch processing

### DIFF
--- a/batchServer/src/batch/batch.service.ts
+++ b/batchServer/src/batch/batch.service.ts
@@ -31,16 +31,30 @@ export class BatchService {
         0,
         batchSize,
       );
-      const createdTransactions: Transaction[] = await Promise.all(
-        transactionsToCreate.map((data: Transaction) =>
-          this.transactionRepository.create(data),
-        ),
-      );
-      await Promise.all(
-        createdTransactions.map((transaction: Transaction) =>
-          this.transactionRepository.save(transaction),
-        ),
-      );
+
+      const bulkInsertData = transactionsToCreate.map((data) => {
+        return { ...data };
+      });
+
+      console.log({ bulkInsertData });
+
+      const query = this.transactionRepository
+        .createQueryBuilder()
+        .insert()
+        .into(Transaction)
+        .values(bulkInsertData);
+      await query.execute();
+
+      //   const createdTransactions: Transaction[] = await Promise.all(
+      //     transactionsToCreate.map((data: Transaction) =>
+      //       this.transactionRepository.create(data),
+      //     ),
+      //   );
+      //   await Promise.all(
+      //     createdTransactions.map((transaction: Transaction) =>
+      //       this.transactionRepository.save(transaction),
+      //     ),
+      //   );
 
       await this.redisService.ltrim('transaction', batchSize, -1);
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,8 @@ services:
       - '80:80'
     depends_on:
       - web
+    networks:
+      - ticket
   web:
     build:
       context: .
@@ -33,6 +35,9 @@ services:
       - '3000'
     logging:
       driver: 'json-file'
+    networks:
+      - ticket
+
   redis:
     image: redis:7.2
     restart: always
@@ -44,6 +49,9 @@ services:
       - ./data/redis-config:/usr/local/etc/redis
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
+    networks:
+      - ticket
+
   db:
     image: postgres:15
     environment:
@@ -64,6 +72,9 @@ services:
       timeout: 5s
       retries: 5
       start_period: 60s
+    networks:
+      - ticket
+
   cron:
     build:
       context: ./batchServer
@@ -76,6 +87,9 @@ services:
         restart: true
       redis:
         condition: service_started
+    networks:
+      - ticket
+
   rabbitmq:
     image: rabbitmq:3-management-alpine
     ports:
@@ -89,3 +103,9 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+    networks:
+      - ticket
+
+networks:
+  ticket:
+    name: ticketingnetwork

--- a/src/rabbit-mq/rabbit-mq.service.ts
+++ b/src/rabbit-mq/rabbit-mq.service.ts
@@ -38,8 +38,10 @@ export class RabbitMqService {
       totalPrice,
     };
     try {
+      await this.client.connect();
       await firstValueFrom(this.client.emit('completedTransaction', data));
       this.logger.log(`Sent ${JSON.stringify(data)} to RabbitMQ`);
+      await this.client.close();
     } catch (error) {
       this.logger.error('Error sending data to RabbitMQ:', error);
     }


### PR DESCRIPTION
배치 processing 성능 개선
- (변경 전) 구매가 완료된 시점으로부터 10분이 경과된 후 캐싱된 구매내역 정보를 DB에 하나씩 생성 -> 대용량 트래픽 발생시 DB접근 횟수가 캐싱 된 데이터의 개수만큼 발생해서 서버가 다운되는 현상
- (변경 후) 하나씩 DB에 생성하지 않고 map함수로 한번에 데이터를 가공 후 한 번의 쿼리로 데이터를 삽입 -> 대용량 트래픽 발생시 DB 접근 횟수가 줄어들어 성능개선 