### PR TITLE
implementing google login is done

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -72,10 +72,12 @@ export class AuthController {
     return this.authService.refresh(user.id, token, res);
   }
 
+  @Public()
   @Get('google/login')
   @UseGuards(AuthGuard('google'))
   async googleAuth() {}
 
+  @Public()
   @Get('oauth2/redirect/google')
   @UseGuards(AuthGuard('google'))
   async googleAuthRedirect(

--- a/src/auth/auth.guard.service.ts
+++ b/src/auth/auth.guard.service.ts
@@ -19,7 +19,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   constructor(
     private readonly reflector: Reflector,
     private readonly jwtService: JwtService,
-    private readonly userSerivce: UserService,
+    private readonly userService: UserService,
   ) {
     super();
   }
@@ -60,7 +60,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     if (roles && roles.includes(Role.ADMIN)) {
       const userId = decoded.sub;
 
-      return this.userSerivce.checkAdminRole(userId);
+      return this.userService.checkAdminRole(userId);
     }
 
     return super.canActivate(context);

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -10,7 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import { RefreshToken } from './entity/refreshToken.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DiscountRate } from 'src/discount-rate/entity/discountRate.entity';
-// import { GoogleStrategy } from './strategies/google.strategy';
+import { GoogleStrategy } from './strategies/google.strategy';
 import { User } from 'src/user/entity/user.entity';
 
 @Module({
@@ -28,7 +28,7 @@ import { User } from 'src/user/entity/user.entity';
   ],
   controllers: [AuthController],
   providers: [
-    // GoogleStrategy,
+    GoogleStrategy,
     AuthService,
     JwtStrategy,
     {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -203,6 +203,8 @@ export class AuthService {
 
     this.sendAuthCookies(res, accessToken, refreshToken);
 
+    console.log({ accessToken: accessToken, refreshToken: refreshToken });
+
     return {
       userId: user.id,
     };

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -1,33 +1,30 @@
-// import { PassportStrategy } from '@nestjs/passport';
-// import { Strategy, VerifyCallback } from 'passport-google-oauth20';
-// import * as dotenv from 'dotenv';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy, VerifyCallback } from 'passport-google-oauth20';
 
-// dotenv.config();
+export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
+  constructor() {
+    super({
+      clientID: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      callbackURL: '/oauth2/redirect/google',
+      scope: ['email', 'profile'],
+    });
+  }
 
-// export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
-//   constructor() {
-//     super({
-//       clientID: process.env.GOOGLE_CLIENT_ID,
-//       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-//       callbackURL: '/oauth2/redirect/google',
-//       scope: ['email', 'profile'],
-//     });
-//   }
-
-//   async validate(
-//     accessToken: string,
-//     refreshToken: string,
-//     profile: any,
-//     done: VerifyCallback,
-//   ) {
-//     try {
-//       const { emails } = profile;
-//       const user = {
-//         email: emails[0].value,
-//       };
-//       done(null, user);
-//     } catch (error) {
-//       done(error);
-//     }
-//   }
-// }
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: any,
+    done: VerifyCallback,
+  ) {
+    try {
+      const { emails } = profile;
+      const user = {
+        email: emails[0].value,
+      };
+      done(null, user);
+    } catch (error) {
+      done(error);
+    }
+  }
+}


### PR DESCRIPTION
- google-login으로 요청
- AuthGaurd('google')에 의해서 google login 화면으로 리다이렉션
- 로그인하면 callback url로 리다이렉션하고 request에는 정보가 담겨있음
- strategy의 validate()에서 profile 반환하고 canActivate에서 request.user에 해당 값 저장
- req & res를 매개변수로 googleLogin 함수 호출
- googleLogin에서는 해당 이메일로 가입한 유저가 DB에 있는지 확인하고 있으면 그대로 유저 반환. 없으면 새로 유저를 DB에 저장
- token 발급 후 쿠키에 저장
- 이후, ticket 조회 페이지로 리다이렉션
- user entity 수정: password:nullable & provider id 