### PR TITLE
jwt-based auth for only graphql queries

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,10 @@
-import { Module, NestModule, MiddlewareConsumer, Logger } from '@nestjs/common';
+import {
+  Module,
+  NestModule,
+  MiddlewareConsumer,
+  Logger,
+  RequestMethod,
+} from '@nestjs/common';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { TicketModule } from './ticket/ticket.module';
@@ -22,6 +28,8 @@ import { PopularTicketResolver } from './popular-ticket/popular-ticket.resolver'
 import { join } from 'path';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
+import { JwtModule } from './jwt/jwt.module';
+import { JwtMiddleWare } from './jwt/jwt.middleware';
 
 @Module({
   imports: [
@@ -84,11 +92,17 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
     CookieModule,
     GraphqlTestModule,
     PopularTicketModule,
+    JwtModule.forRoot({
+      privateKey: process.env.JWT_PRIVATE_KEY,
+    }),
   ],
   providers: [Logger],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(JwtMiddleWare)
+      .forRoutes({ path: '/graphql', method: RequestMethod.ALL });
     // consumer.apply(LoggerContextMiddleware).forRoutes('*');
   }
 }

--- a/src/common/entities/base.dto.ts
+++ b/src/common/entities/base.dto.ts
@@ -1,0 +1,9 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class BaseOutput {
+  @Field(() => Boolean)
+  ok: boolean;
+  @Field(() => String, { nullable: true })
+  error?: string;
+}

--- a/src/jwt/jwt.middleware.ts
+++ b/src/jwt/jwt.middleware.ts
@@ -1,0 +1,32 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { UserService } from 'src/user/user.service';
+import { JwtService } from './jwt.service';
+import { JWT_HEADER } from './jwt.type';
+
+@Injectable()
+export class JwtMiddleWare implements NestMiddleware {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly userService: UserService,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    console.log({ header: req.headers });
+    if (JWT_HEADER in req.headers) {
+      const token = req.headers[JWT_HEADER];
+      const decoded = this.jwtService.verify(token.toString());
+      if (typeof decoded === 'object' && 'id' in decoded) {
+        try {
+          const user = await this.userService.findOne(decoded['id']);
+          console.log({ user });
+          req['user'] = user;
+        } catch (error) {
+          console.error(error);
+        }
+      }
+    }
+
+    next();
+  }
+}

--- a/src/jwt/jwt.module.ts
+++ b/src/jwt/jwt.module.ts
@@ -1,0 +1,21 @@
+import { DynamicModule, Global, Module } from '@nestjs/common';
+import { JwtService } from './jwt.service';
+import { JwtModuleOptions, JWT_CONFIG } from './jwt.type';
+
+@Module({})
+@Global()
+export class JwtModule {
+  static forRoot(option: JwtModuleOptions): DynamicModule {
+    return {
+      module: JwtModule,
+      providers: [
+        {
+          provide: JWT_CONFIG,
+          useValue: option,
+        },
+        JwtService,
+      ],
+      exports: [JwtService],
+    };
+  }
+}

--- a/src/jwt/jwt.service.spec.ts
+++ b/src/jwt/jwt.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from './jwt.service';
+
+describe('JwtService', () => {
+  let service: JwtService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [JwtService],
+    }).compile();
+
+    service = module.get<JwtService>(JwtService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/jwt/jwt.service.ts
+++ b/src/jwt/jwt.service.ts
@@ -1,0 +1,16 @@
+import { JwtModuleOptions, JWT_CONFIG } from './jwt.type';
+import { Inject, Injectable } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JwtService {
+  constructor(@Inject(JWT_CONFIG) private readonly option: JwtModuleOptions) {}
+
+  signin(id: string): string {
+    return jwt.sign({ id }, this.option.privateKey);
+  }
+
+  verify(token: string) {
+    return jwt.verify(token, this.option.privateKey);
+  }
+}

--- a/src/jwt/jwt.type.ts
+++ b/src/jwt/jwt.type.ts
@@ -1,0 +1,7 @@
+export interface JwtModuleOptions {
+  privateKey: string;
+}
+
+export const JWT_CONFIG = 'jwtOption';
+
+export const JWT_HEADER = 'x-jwt';

--- a/src/popular-ticket/dto/create-popular-ticket.dto.ts
+++ b/src/popular-ticket/dto/create-popular-ticket.dto.ts
@@ -5,6 +5,7 @@ import {
   PartialType,
   PickType,
 } from '@nestjs/graphql';
+import { BaseOutput } from 'src/common/entities/base.dto';
 import { Ticket } from 'src/ticket/entity/ticket.entity';
 import { Category, Status } from 'src/ticket/type/ticket.enum';
 
@@ -20,12 +21,7 @@ export class CreatePopularTicketInput extends PickType(Ticket, [
 ]) {}
 
 @ObjectType()
-export class CreatePopularTicketOutput {
-  @Field(() => String, { nullable: true })
-  error?: string;
-  @Field(() => Boolean)
-  ok: boolean;
-}
+export class CreatePopularTicketOutput extends BaseOutput {}
 
 @InputType()
 export class GetPopularTicketInput extends PartialType(

--- a/src/user/dto/req.dto.ts
+++ b/src/user/dto/req.dto.ts
@@ -1,3 +1,4 @@
+import { Field, InputType, ObjectType, PickType } from '@nestjs/graphql';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEmail,
@@ -9,6 +10,8 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
+import { BaseOutput } from 'src/common/entities/base.dto';
+import { User } from '../entity/user.entity';
 import { Membership, Role } from '../type/user.enum';
 
 export class FindUserReqDto {
@@ -90,4 +93,26 @@ export class IssueCouponReqDto {
   })
   @IsNumber()
   couponId: number;
+}
+
+@InputType()
+export class CreateAccountInput extends PickType(User, [
+  'email',
+  'password',
+  'role',
+]) {
+  @Field(() => String)
+  confirmPassword: string;
+}
+
+@ObjectType()
+export class CreateAccountOutput extends BaseOutput {}
+
+@InputType()
+export class SigninInput extends PickType(User, ['email', 'password']) {}
+
+@ObjectType()
+export class SigninOutput extends BaseOutput {
+  @Field(() => String, { nullable: true })
+  token?: string;
 }

--- a/src/user/entity/user.entity.ts
+++ b/src/user/entity/user.entity.ts
@@ -19,34 +19,79 @@ import { Membership, Role } from '../type/user.enum';
 import { Transaction } from './transaction.entity';
 import { IsOptional } from 'class-validator';
 import { ProviderType } from 'src/auth/type/auth.type';
+import {
+  Field,
+  InputType,
+  ObjectType,
+  registerEnumType,
+} from '@nestjs/graphql';
+import { InternalServerErrorException } from '@nestjs/common';
 
+registerEnumType(Role, { name: 'Role' });
+
+@InputType({
+  isAbstract: true,
+})
+@ObjectType()
 @Entity()
 export class User {
   @PrimaryGeneratedColumn('uuid')
+  @Field(() => String)
   id: string;
 
   @Column({
     unique: true,
   })
+  @Field(() => String)
   email: string;
 
   @Column({ nullable: true })
   @IsOptional()
+  @Field(() => String, { nullable: true })
   password: string;
 
   @Column({ default: 'none' })
+  @Field(() => String)
   provider: string;
 
   @Column({ type: 'enum', enum: Role })
+  @Field(() => Role)
   role: Role = Role.CONSUMER;
 
   @Column({ type: 'enum', enum: Membership })
+  @Field(() => Membership)
   membership: Membership = Membership.BRONZE;
 
+  @Column({ default: false })
+  @Field(() => Boolean)
+  verified: boolean;
+
+  // @BeforeInsert()
+  // async hashPassword(): Promise<void> {
+  //   try {
+
+  //     this.password = await bcrypt.hash(this.password)
+
+  //   } catch(error) {
+  //     throw new InternalServerErrorException();
+  //   }
+  // }
+
+  // async isMatchedPassword(password: string): Promise<boolean> {
+  // try {
+  //   const isMatch = await bcrypt.compare(password, this.password);
+  //   return isMatch
+  // } catch (error) {
+  //   throw new InternalServerErrorException()
+  // }
+  // }
+
   @CreateDateColumn({ name: 'created_at' })
+  @Field(() => Date)
   createdAt: Date;
 
   @UpdateDateColumn({ name: 'updated_at' })
+  @Field(() => Date)
   updatedAt: Date;
 
   @ManyToOne(() => DiscountRate, (discountRate) => discountRate.users)

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -9,14 +9,15 @@ import { DiscountRate } from 'src/discount-rate/entity/discountRate.entity';
 import { Transaction } from './entity/transaction.entity';
 import { Coupon } from 'src/coupon/entity/coupon.entity';
 import { RabbitMqModule } from 'src/rabbit-mq/rabbit-mq.module';
+import { UserResolver } from './user.resolver';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Ticket, DiscountRate, Transaction, Coupon]),
-    RedisModule,
+    TypeOrmModule.forFeature([User, Ticket, DiscountRate, Transaction, Coupon]), //forFeature: dynamic module: uses register to create a function like forRoot
+    RedisModule, //static module
     RabbitMqModule,
   ],
-  providers: [UserService, Logger],
+  providers: [UserService, Logger, UserResolver],
   controllers: [UserController],
   exports: [UserService],
 })

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,0 +1,41 @@
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Test } from 'src/common/decorator/public.decorator';
+import {
+  CreateAccountInput,
+  CreateAccountOutput,
+  SigninInput,
+  SigninOutput,
+} from './dto/req.dto';
+import { User } from './entity/user.entity';
+import { UserService } from './user.service';
+
+@Resolver(() => User)
+export class UserResolver {
+  constructor(private readonly userSerive: UserService) {}
+
+  @Test()
+  @Mutation(() => CreateAccountOutput)
+  async createAccount(
+    @Args('input') createAccountInput: CreateAccountInput,
+  ): Promise<CreateAccountOutput> {
+    const { ok, error } =
+      await this.userSerive.createAccount(createAccountInput);
+
+    return {
+      ok,
+      error,
+    };
+  }
+
+  @Test()
+  @Mutation(() => SigninOutput)
+  async signin(@Args('input') signinInput: SigninInput): Promise<SigninOutput> {
+    const { ok, error, token } = await this.userSerive.signin(signinInput);
+
+    return {
+      ok,
+      error,
+      token,
+    };
+  }
+}


### PR DESCRIPTION
Graphql 쿼리를 위한 jwt auth 시스템
- graphql 쿼리에 적용하는 jwt middleware 설정
- jwt module 설정: static하게 forRoot만들어서 필요한 module, provider, export return ex. JWT_CONFIG, JWT_PRIVATE_KEY
- jwt service에서 토큰 생성 및 토큰 검증 
- graphql 쿼리로 회원가입 및 로그인 기능 추가 
